### PR TITLE
Add .gitignore for built ctree files

### DIFF
--- a/core/ctree/.gitignore
+++ b/core/ctree/.gitignore
@@ -1,0 +1,3 @@
+cytree.cpp
+cytree.cpython-*
+build/


### PR DESCRIPTION
After building the ctree files using make.sh, it tries to mark the build files as updates to the git repo.

This .gitignore file will prevent people from accidentally committing these files.